### PR TITLE
Slight performance improvements

### DIFF
--- a/bordercontrol/cmd/bordercontrol/main.go
+++ b/bordercontrol/cmd/bordercontrol/main.go
@@ -70,7 +70,7 @@ const (
 var (
 	// App config, command line & env var configuration
 	app = cli.App{
-		Version: "0.0.2c",
+		Version: "0.0.3",
 		Name:    "plane.watch bordercontrol",
 		Usage:   "Proxy for multiple stunnel-based BEAST & MLAT endpoints",
 		Description: `This program acts as a server for multiple stunnel-based endpoints, ` +

--- a/bordercontrol/lib/feedproxy/feedproxy_connections.go
+++ b/bordercontrol/lib/feedproxy/feedproxy_connections.go
@@ -360,6 +360,8 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 		connA, connB net.Conn
 		// connAName, connBName  string
 		incrementByteCounters func(uuid uuid.UUID, connNum uint, proto feedprotocol.Protocol, bytes uint64) error
+		bytesRead             int
+		err                   error
 	)
 
 	// set up function for specific direction
@@ -398,11 +400,11 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 		default:
 
 			// read from feeder client
-			err := connA.SetReadDeadline(time.Now().Add(time.Second * 1))
+			err = connA.SetReadDeadline(time.Now().Add(time.Second * 1))
 			if err != nil {
 				return err
 			}
-			bytesRead, err := connA.Read(buf)
+			bytesRead, err = connA.Read(buf)
 			if err != nil {
 				// don't close connection on read deadline exceeded - client may have nothing to send...
 				if !errors.Is(err, os.ErrDeadlineExceeded) {
@@ -411,7 +413,7 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 			} else {
 
 				// write to server
-				err := connB.SetWriteDeadline(time.Now().Add(time.Second * 2))
+				err = connB.SetWriteDeadline(time.Now().Add(time.Second * 2))
 				if err != nil {
 					return err
 				}

--- a/bordercontrol/lib/feedproxy/feedproxy_connections.go
+++ b/bordercontrol/lib/feedproxy/feedproxy_connections.go
@@ -53,7 +53,7 @@ const (
 	maxIncomingConnectionRequestSeconds   = 10
 
 	// network send/recv buffer size
-	sendRecvBufferSize = 256 * 1024 // 256kB
+	sendRecvBufferSize = 32000 // 32kB
 )
 
 var (
@@ -389,7 +389,7 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 
 	// log := conf.log.With().Str("proxy", directionStr).Logger()
 	timer := time.Now()
-	byteCount := int(0)
+	byteCount := uint64(0)
 	buf := make([]byte, sendRecvBufferSize)
 	for {
 
@@ -423,14 +423,14 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 				}
 
 				// increase byte counter
-				byteCount += bytesRead
+				byteCount += uint64(bytesRead)
 
 			}
 
-			// update stats every second or when counter is close to wrapping
-			if time.Now().After(timer.Add(time.Second)) || byteCount > 20000 {
+			// update stats every second
+			if time.Now().After(timer.Add(time.Second)) {
 				timer = time.Now()
-				err = incrementByteCounters(conf.clientApiKey, conf.connNum, conf.proto, uint64(byteCount))
+				err = incrementByteCounters(conf.clientApiKey, conf.connNum, conf.proto, byteCount)
 				if err != nil {
 					return err
 				}

--- a/bordercontrol/lib/feedproxy/feedproxy_connections.go
+++ b/bordercontrol/lib/feedproxy/feedproxy_connections.go
@@ -420,15 +420,14 @@ func protocolProxy(conf *protocolProxyConfig, direction proxyDirection) error {
 					return err
 				}
 
-				// don't update stats every read
+				// increase byte counter
 				byteCount += bytesRead
 
 			}
 
-			// update stats ever second
+			// update stats every second or when counter is close to wrapping
 			if time.Now().After(timer.Add(time.Second)) || byteCount > 20000 {
 				timer = time.Now()
-				// update stats
 				err = incrementByteCounters(conf.clientApiKey, conf.connNum, conf.proto, uint64(byteCount))
 				if err != nil {
 					return err


### PR DESCRIPTION
- Attempt to reduce/remove allocs in `protocolProxy`, the main data mover function.
- Stats were being updated every read/write in `protocolProxy`. There's now a timer that will update them every second instead.
- Reduce read/write buffer to 32K (from 256K).